### PR TITLE
Feature/board service: Suspended item 조회

### DIFF
--- a/src/main/java/me/nettee/board/application/service/BoardQueryService.java
+++ b/src/main/java/me/nettee/board/application/service/BoardQueryService.java
@@ -28,6 +28,14 @@ public class BoardQueryService implements BoardReadUseCase, BoardReadByStatusesU
 
     @Override
     public Page<BoardSummary> findByStatuses(Set<BoardStatus> statuses, Pageable pageable) {
-        return boardQueryPort.findByStatusesList(statuses, pageable);
+        var boardPage = boardQueryPort.findByStatusesList(statuses, pageable);
+
+        var filterBoardPage = boardPage.map(board ->
+                board.status() == BoardStatus.SUSPENDED
+                        ? new BoardSummary(board.id(), null, board.status(), board.createdAt(), board.updatedAt())
+                        : board
+        );
+
+        return filterBoardPage;
     }
 }

--- a/src/main/java/me/nettee/board/application/service/BoardQueryService.java
+++ b/src/main/java/me/nettee/board/application/service/BoardQueryService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import static me.nettee.board.application.exception.BoardQueryErrorCode.BOARD_FORBIDDEN;
 import static me.nettee.board.application.exception.BoardQueryErrorCode.BOARD_NOT_FOUND;
 
 @Service
@@ -22,8 +23,14 @@ public class BoardQueryService implements BoardReadUseCase, BoardReadByStatusesU
 
     @Override
     public BoardDetail getBoard(Long id) {
-        return boardQueryPort.findById(id)
+        BoardDetail boardDetail =  boardQueryPort.findById(id)
                 .orElseThrow(BOARD_NOT_FOUND::exception);
+
+        if (boardDetail.status() == BoardStatus.SUSPENDED) {
+            throw BOARD_FORBIDDEN.exception();
+        }
+
+        return boardDetail;
     }
 
     @Override

--- a/src/test/kotlin/me/nettee/board/application/service/BoardQueryServiceTest.kt
+++ b/src/test/kotlin/me/nettee/board/application/service/BoardQueryServiceTest.kt
@@ -3,10 +3,12 @@ package me.nettee.board.application.service
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.nettee.board.application.domain.type.BoardStatus
+import me.nettee.board.application.exception.BoardQueryErrorCode.BOARD_FORBIDDEN
 import me.nettee.board.application.exception.BoardQueryErrorCode.BOARD_NOT_FOUND
 import me.nettee.board.application.exception.BoardQueryException
 import me.nettee.board.application.model.BoardQueryModels.BoardDetail
@@ -22,6 +24,10 @@ class BoardQueryServiceTest : FreeSpec({
 
     val boardQueryPort = mockk<BoardQueryPort>() // mocking
     val boardQueryService = BoardQueryService(boardQueryPort) // 주입
+
+    beforeTest {
+        clearMocks(boardQueryPort)
+    }
 
     "BoardQueryService" - {
         "getBoard" - {
@@ -49,6 +55,35 @@ class BoardQueryServiceTest : FreeSpec({
 
                 // then
                 result shouldBe expectedDetail
+                verify(exactly = 1) { boardQueryPort.findById(boardId) }
+            }
+
+            "[예외] boardDetail status가 suspended 일 때 Exception 발생" {
+                // given
+                val boardId = 1L
+                val now = Instant.now()
+
+                val expectedDetail = BoardDetail(
+                    boardId,
+                    "Test Title",
+                    "test Content",
+                    BoardStatus.SUSPENDED,
+                    now,
+                    now
+                )
+
+                every {
+                    boardQueryPort.findById(boardId)
+                } returns Optional.of(expectedDetail)
+
+                // when
+                val exception = shouldThrow<BoardQueryException> {
+                    boardQueryService.getBoard(boardId)
+                }
+
+                // then
+                exception.errorCode shouldBe BOARD_FORBIDDEN
+
                 verify(exactly = 1) { boardQueryPort.findById(boardId) }
             }
 
@@ -129,8 +164,6 @@ class BoardQueryServiceTest : FreeSpec({
                 result shouldBe expectedPage
                 verify(exactly = 1) { boardQueryPort.findByStatusesList(statuses, pageable) }
             }
-
-
         }
     }
 })

--- a/src/test/kotlin/me/nettee/board/application/service/BoardQueryServiceTest.kt
+++ b/src/test/kotlin/me/nettee/board/application/service/BoardQueryServiceTest.kt
@@ -7,8 +7,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.nettee.board.application.domain.type.BoardStatus
-import me.nettee.board.application.exception.BoardCommandErrorCode.BOARD_NOT_FOUND
-import me.nettee.board.application.exception.BoardCommandException
+import me.nettee.board.application.exception.BoardQueryErrorCode.BOARD_NOT_FOUND
+import me.nettee.board.application.exception.BoardQueryException
 import me.nettee.board.application.model.BoardQueryModels.BoardDetail
 import me.nettee.board.application.model.BoardQueryModels.BoardSummary
 import me.nettee.board.application.port.BoardQueryPort
@@ -60,7 +60,7 @@ class BoardQueryServiceTest : FreeSpec({
                 } returns Optional.empty()
 
                 // when & then
-                val exception = shouldThrow<BoardCommandException> {
+                val exception = shouldThrow<BoardQueryException> {
                     boardQueryService.getBoard(boardId)
                 }
                 exception.errorCode shouldBe BOARD_NOT_FOUND
@@ -87,7 +87,7 @@ class BoardQueryServiceTest : FreeSpec({
                         ),
                         BoardSummary(
                                 2L,
-                                "Suspended Board",
+                                null,
                                 BoardStatus.SUSPENDED,
                                 now,
                                 now
@@ -129,6 +129,8 @@ class BoardQueryServiceTest : FreeSpec({
                 result shouldBe expectedPage
                 verify(exactly = 1) { boardQueryPort.findByStatusesList(statuses, pageable) }
             }
+
+
         }
     }
 })


### PR DESCRIPTION
# Pull Request

## Issues

Resolves #71 

## Description
* Board 목록 조회 시, SUSPENDED 상태의 아이템은 제목을 제거했습니다.
* Board 단건 조회 시, SUSPENDED 상태의 아이템에 대해 403 Forbidden 응답과 적절한 안내 메시지를 반환하도록 처리했습니다.
* 테스트 코드에서 boardDetail.status가 SUSPENDED일 때 예외가 발생하는 케이스를 추가했습니다.
* 테스트 코드에서 BoardStatus로 목록을 조회하는 경우, status가 SUSPENDED이고 title이 null인 객체를 추가하여 검증했습니다.

## How Has This Been Tested?

- 테스트 환경: OpenJDK 21(Amazon Corretto 21), kotest (mockk 라이브러리) with FreeSpec.