### PR TITLE
Feature/board driving : 불필요한 코드 삭제 및 mapper config 외부 연결.

### DIFF
--- a/src/test/kotlin/me/nettee/board/adapter/driving/web/BoardQueryApiTest.kt
+++ b/src/test/kotlin/me/nettee/board/adapter/driving/web/BoardQueryApiTest.kt
@@ -11,6 +11,7 @@ import me.nettee.board.application.model.BoardQueryModels.BoardSummary
 import me.nettee.board.application.model.BoardQueryModels.BoardDetail
 import me.nettee.board.application.usecase.BoardReadByStatusesUseCase
 import me.nettee.board.application.usecase.BoardReadUseCase
+import me.nettee.core.config.JacksonTestConfig
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.argThat
@@ -19,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -35,6 +37,7 @@ import java.time.Instant
 
 @WebMvcTest(BoardQueryApi::class)
 @ExtendWith(SpringExtension::class)
+@Import(JacksonTestConfig::class)
 class BoardQueryApiTest(
     @MockitoBean private val boardReadUseCase: BoardReadUseCase,
     @MockitoBean private val boardReadByStatusesUseCase: BoardReadByStatusesUseCase,
@@ -148,19 +151,4 @@ class BoardQueryApiTest(
         `when`(boardDtoMapper.toDtoDetail(boardDetail)).thenReturn(BoardDetailResponse(boardDetail))
         `when`(boardDtoMapper.toDtoDetail(boardDetailWithNull)).thenReturn(BoardDetailResponse(boardDetailWithNull))
     }
-}) {
-    @TestConfiguration
-    class JacksonTestConfig {
-        @Bean
-        fun objectMapper(): ObjectMapper {
-            return ObjectMapper()
-                .registerModule(JavaTimeModule())
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        }
-
-        @Bean
-        fun mappingJackson2HttpMessageConverter(objectMapper: ObjectMapper): MappingJackson2HttpMessageConverter {
-            return MappingJackson2HttpMessageConverter(objectMapper)
-        }
-    }
-}
+})

--- a/src/test/kotlin/me/nettee/board/adapter/driving/web/BoardQueryApiTest.kt
+++ b/src/test/kotlin/me/nettee/board/adapter/driving/web/BoardQueryApiTest.kt
@@ -1,8 +1,5 @@
 package me.nettee.board.adapter.driving.web
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.kotest.core.spec.style.FreeSpec
 import me.nettee.board.adapter.driving.web.dto.BoardQueryDto.BoardDetailResponse
 import me.nettee.board.adapter.driving.web.mapper.BoardDtoMapper
@@ -18,15 +15,12 @@ import org.mockito.ArgumentMatchers.argThat
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc

--- a/src/test/kotlin/me/nettee/board/adapter/driving/web/BoardQueryApiTest.kt
+++ b/src/test/kotlin/me/nettee/board/adapter/driving/web/BoardQueryApiTest.kt
@@ -107,11 +107,6 @@ class BoardQueryApiTest(
     ) -> Page<BoardSummary>
 
     beforeSpec {
-        val objectMapper = ObjectMapper().apply {
-            registerModule(JavaTimeModule())
-            setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        }
-
         boardReadSummaryModelPage = { boardList, pageable, boardStatus ->
             val filteredBoards = boardList
                 .takeIf { it.isNotEmpty() }
@@ -137,9 +132,6 @@ class BoardQueryApiTest(
             )
         }
 
-        val jsonResult = objectMapper.writeValueAsString(boardDetailWithNull)
-        val nonNullResponse = objectMapper.readValue(jsonResult, BoardDetail::class.java)
-
         `when`(boardReadUseCase.getBoard(1L)).thenAnswer { boardDetail }
         `when`(boardReadUseCase.getBoard(2L)).thenAnswer { boardDetailWithNull }
         `when`(boardReadUseCase.getBoard(argThat { it != 1L && it != 2L })).thenThrow(ResponseStatusException(HttpStatus.NOT_FOUND))
@@ -154,7 +146,7 @@ class BoardQueryApiTest(
             boardReadSummaryModelPage(boardList, pageable, statuses)
         }
         `when`(boardDtoMapper.toDtoDetail(boardDetail)).thenReturn(BoardDetailResponse(boardDetail))
-        `when`(boardDtoMapper.toDtoDetail(boardDetailWithNull)).thenReturn(BoardDetailResponse(nonNullResponse))
+        `when`(boardDtoMapper.toDtoDetail(boardDetailWithNull)).thenReturn(BoardDetailResponse(boardDetailWithNull))
     }
 }) {
     @TestConfiguration

--- a/src/test/kotlin/me/nettee/core/config/JacksonTestConfig.kt
+++ b/src/test/kotlin/me/nettee/core/config/JacksonTestConfig.kt
@@ -1,0 +1,23 @@
+package me.nettee.core.config
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+
+@TestConfiguration
+class JacksonTestConfig {
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        return ObjectMapper()
+                .registerModule(JavaTimeModule())
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    }
+
+    @Bean
+    fun mappingJackson2HttpMessageConverter(objectMapper: ObjectMapper): MappingJackson2HttpMessageConverter {
+        return MappingJackson2HttpMessageConverter(objectMapper)
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issues
Resolves #73  
Resolves #75  
Resolves #76 

## Description

- 불필요코드를 삭제(#76)
: beforeSpec내의 110~114번줄, 이와 연결된 140,141번줄, 157번의 코드를 수정하였습니다. nonNullResponse >> boardDetailWithNull로 변경함.
- 내부의 config 관련 코드를 외부로 이동(#75)
: 내부에 있던 jackson mapper config 내용을 외부로 이동시켰습니다.(test의 core.config 내에 JacksonTestConfig.kt 파일 생성 후 이동시킴)

## How Has This Been Tested?

- 테스트 환경: OpenJDK 21(Amazon Corretto 21), kotest (mockk 라이브러리) with FreeSpec.