### PR TITLE
Feature/common: GlobalExceptionHandler 코어로부터 Jackson 종속성 제거 작업

### DIFF
--- a/src/main/java/me/nettee/common/exeption/response/ApiErrorResponse.java
+++ b/src/main/java/me/nettee/common/exeption/response/ApiErrorResponse.java
@@ -1,7 +1,5 @@
 package me.nettee.common.exeption.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Map;
 import lombok.Builder;
 
@@ -10,6 +8,12 @@ public record ApiErrorResponse(
         int status,
         String code,
         String message,
-        @JsonInclude(Include.NON_EMPTY)
         Map<String, Object> payload
-) {}
+) {
+        public ApiErrorResponse {
+                if (payload != null && payload.isEmpty()) {
+                        payload = null;
+                }
+        }
+}
+

--- a/src/main/java/me/nettee/common/exeption/response/ApiErrorResponse.java
+++ b/src/main/java/me/nettee/common/exeption/response/ApiErrorResponse.java
@@ -10,10 +10,10 @@ public record ApiErrorResponse(
         String message,
         Map<String, Object> payload
 ) {
-        public ApiErrorResponse {
-                if (payload != null && payload.isEmpty()) {
-                        payload = null;
-                }
+    public ApiErrorResponse {
+        if (payload != null && payload.isEmpty()) {
+            payload = null;
         }
+    }
 }
 

--- a/src/test/kotlin/me/nettee/common/ApiErrorResponseTest.kt
+++ b/src/test/kotlin/me/nettee/common/ApiErrorResponseTest.kt
@@ -1,0 +1,76 @@
+package me.nettee.common
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import me.nettee.common.exeption.response.ApiErrorResponse
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(val message: String, val httpStatus: HttpStatus) {
+    BOARD_NOT_FOUND("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+}
+
+class ApiErrorResponseTest : FreeSpec({
+    // 공통 검증 로직
+    fun ApiErrorResponse.shouldBeBoardNotFound() {
+        status() shouldBe 404
+        code() shouldBe "BOARD_NOT_FOUND"
+        message() shouldBe "게시물을 찾을 수 없습니다."
+    }
+
+    // 공통 상수
+    val status = ErrorCode.BOARD_NOT_FOUND.httpStatus.value()
+    val code = ErrorCode.BOARD_NOT_FOUND.name
+    val message = ErrorCode.BOARD_NOT_FOUND.message
+
+    // 빌더 전역 변수
+    val baseResponseBuilder = ApiErrorResponse.builder()
+            .status(status)
+            .code(code)
+            .message(message)
+
+    "생성자 테스트" - {
+        "with null payload" {
+            val response = ApiErrorResponse(status, code, message, null)
+            response.shouldBeBoardNotFound()
+            response.payload().shouldBeNull()
+        }
+
+        "with empty payload" {
+            val response = ApiErrorResponse(status, code, message, emptyMap<String, Any>())
+            response.shouldBeBoardNotFound()
+            response.payload().shouldBeNull()
+        }
+
+        "with non-empty payload" {
+            val payload = mapOf("key" to "value")
+            val response = ApiErrorResponse(status, code, message, payload)
+            response.shouldBeBoardNotFound()
+            response.payload() shouldNotBe null
+            response.payload() shouldBe payload
+        }
+    }
+
+    "빌더 테스트" - {
+        "with null payload" {
+            val response = baseResponseBuilder.payload(null).build()
+            response.shouldBeBoardNotFound()
+            response.payload().shouldBeNull()
+        }
+
+        "with empty payload" {
+            val response = baseResponseBuilder.payload(emptyMap<String, Any>()).build()
+            response.shouldBeBoardNotFound()
+            response.payload().shouldBeNull()
+        }
+
+        "with non-empty payload" {
+            val payload = mapOf("key" to "value")
+            val response = baseResponseBuilder.payload(payload).build()
+            response.shouldBeBoardNotFound()
+            response.payload() shouldNotBe null
+            response.payload() shouldBe payload
+        }
+    }
+})


### PR DESCRIPTION
# Pull Request

## Issues

Resolves #74

## Description

```java
@Builder
public record ApiErrorResponse(
        int status,
        String code,
        String message,
        Map<String, Object> payload
) {
        public ApiErrorResponse {
                if (payload != null && payload.isEmpty()) {
                        payload = null;
                }
        }
}
```

- GlobalExceptionHandler: ApiErrorResponse에서 @JsonInclude를 제거하였습니다.
-  GlobalExceptionHandler: ApiErrorResponse.payload 필드가 빈 컬렉션이면 null로 대치하였습니다.

<br />

```kotlin
    "생성자 테스트" - {
        "with null payload" {
            val response = ApiErrorResponse(status, code, message, null)
            response.shouldBeBoardNotFound()
            response.payload().shouldBeNull()
        }

        "with empty payload" {
            val response = ApiErrorResponse(status, code, message, emptyMap<String, Any>())
            response.shouldBeBoardNotFound()
            response.payload().shouldBeNull()
        }

        "with non-empty payload" {
            val payload = mapOf("key" to "value")
            val response = ApiErrorResponse(status, code, message, payload)
            response.shouldBeBoardNotFound()
            response.payload() shouldNotBe null
            response.payload() shouldBe payload
        }
    }
```

- ApiErrorResponse의 생성자와 빌더가 다양한 페이로드 상태(null, 빈 맵, 비어 있지 않은 맵)에 대해 올바르게 응답하는지 검증합니다.

## How Has This Been Tested?

- 테스트 환경: OpenJDK 21(Amazon Corretto 21), kotest (mockk 라이브러리) with FreeSpec.
